### PR TITLE
Disable Layout/FirstMethodArgumentLineBreak

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -7,7 +7,7 @@ Layout/FirstArrayElementLineBreak:
 Layout/FirstHashElementLineBreak:
   Enabled: true
 Layout/FirstMethodArgumentLineBreak:
-  Enabled: true
+  Enabled: false
 Layout/FirstMethodParameterLineBreak:
   Enabled: true
 Layout/FirstParameterIndentation:


### PR DESCRIPTION
This prohibited nice things like:

```ruby
foo(:bar, {
  x: 1,
  y: 2,
})
```

Which are easier to read than most alternatives.